### PR TITLE
[TASK] Set `commitMessageLowerCase` to `never`

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,6 +20,7 @@
 		"eliashaeussler"
 	],
 	"commitBodyTable": true,
+	"commitMessageLowerCase": "never",
 	"commitMessagePrefix": "[TASK]",
 	"commitMessageTopic": "{{depName}}",
 	"composerIgnorePlatformReqs": null,


### PR DESCRIPTION
Since we don't use semantic commits, commit messages should never be lower-cased.