### PR TITLE
[TASK] Handle PHP requirement specifically

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,14 +31,15 @@
 	},
 	"packageRules": [
 		{
-			"description": "Disable automerge for PHP dependency updates",
+			"description": "Handle PHP requirement specifically",
 			"extends": [
 				":automergeDisabled"
 			],
 			"ignoreUnstable": false,
 			"matchPackageNames": [
 				"php"
-			]
+			],
+			"rangeStrategy": "widen"
 		}
 	],
 	"platformAutomerge": true,


### PR DESCRIPTION
The `php` requirement is considered a meta-dependency and must therefore be handled specifically.