### PR TITLE
[TASK] Don't extend TYPO3 extension preset from default preset

### DIFF
--- a/typo3-extension.json
+++ b/typo3-extension.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"local>eliashaeussler/renovate-config"
-	],
 	"composerIgnorePlatformReqs": [
 		"ext-intl"
 	],


### PR DESCRIPTION
Presets are now decoupled from each other, making it easier to use them standalone and make their usages more explicit.