### PR TITLE
[BUGFIX] Disable `dependencyDashboardOSVVulnerabilitySummary`

### DIFF
--- a/default.json
+++ b/default.json
@@ -22,7 +22,6 @@
 	"commitMessageTopic": "{{depName}}",
 	"composerIgnorePlatformReqs": null,
 	"configMigration": true,
-	"dependencyDashboardOSVVulnerabilitySummary": "unresolved",
 	"lockFileMaintenance": {
 		"enabled": true,
 		"extends": [


### PR DESCRIPTION
The config option `dependencyDashboardOSVVulnerabilitySummary` causes rate limiting errors and is therefore disabled.