### PR TITLE
[TASK] Include E2E test suites in default preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,6 +41,12 @@
 				"php"
 			],
 			"rangeStrategy": "widen"
+		},
+		{
+			"description": "Include packages from E2E test suites",
+			"matchFileNames": [
+				"tests/e2e/**"
+			]
 		}
 	],
 	"platformAutomerge": true,


### PR DESCRIPTION
This PR adds a new package rule to the default preset that includes all packages from E2E test suites. This is necessary as the included preset `:ignoreModulesAndTests` previously excluded those packages.