### PR TITLE
[BUGFIX] Disable patch updates for PHP

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,24 @@
 				"containerbase/php-prebuild"
 			],
 			"rangeStrategy": "widen"
+		},
+		{
+			"description": "Disable patch updates for PHP",
+			"extends": [
+				":disableRenovate"
+			],
+			"matchManagers": [
+				"regex"
+			],
+			"matchDepNames": [
+				"php"
+			],
+			"matchPackageNames": [
+				"containerbase/php-prebuild"
+			],
+			"matchUpdateTypes": [
+				"patch"
+			]
 		}
 	],
 	"platformAutomerge": true,


### PR DESCRIPTION
This PR disables patch updates for PHP versions configured in GitHub workflows.