### PR TITLE
[TASK] Group GitHub artifact actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -70,6 +70,14 @@
 			"matchDepNames": [
 				"php"
 			]
+		},
+		{
+			"description": "Group GitHub artifact actions",
+			"matchDepNames": [
+				"actions/download-artifact",
+				"actions/upload-artifact"
+			],
+			"groupName": "GitHub artifact actions"
 		}
 	],
 	"platformAutomerge": true,


### PR DESCRIPTION
This PR adds a new package rule to group updates of `actions/*-artifact` actions, since they are tightly coupled to each other.