### PR TITLE
[TASK] Re-enable OSV vulnerability alerts

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,6 +36,7 @@
 			"versioningTemplate": "docker"
 		}
 	],
+	"dependencyDashboardOSVVulnerabilitySummary": "unresolved",
 	"lockFileMaintenance": {
 		"enabled": true,
 		"extends": [

--- a/default.json
+++ b/default.json
@@ -44,6 +44,7 @@
 		],
 		"commitMessageAction": "Update all dependencies"
 	},
+	"osvVulnerabilityAlerts": true,
 	"packageRules": [
 		{
 			"description": "Handle PHP requirement specifically",


### PR DESCRIPTION
Since renovatebot/renovate#26808 requests to OSV use the preconfigured GitHub token. Therefore, there should be no 401 responses anymore and we can safely re-enable OSV vulnerability alerts.