### PR TITLE
[TASK] Group TYPO3 CMS dependencies

### DIFF
--- a/typo3-extension.json
+++ b/typo3-extension.json
@@ -12,6 +12,18 @@
 			"rangeStrategy": "widen"
 		},
 		{
+			"description": "Group TYPO3 CMS dependencies",
+			"matchPackagePrefixes": [
+				"typo3/cms-"
+			],
+			"excludePackageNames": [
+				"typo3/cms-cli",
+				"typo3/cms-composer-installers"
+			],
+			"groupName": "TYPO3 CMS",
+			"fetchReleaseNotes": false
+		},
+		{
 			"description": "Disable Renovate for all fixture extensions used in functional tests",
 			"extends": [
 				":disableRenovate"


### PR DESCRIPTION
This PR adds a new `TYPO3 CMS` group to the `typo3-extension` preset that groups all `typo3/cms-*` packages.