### PR TITLE
[BUGFIX] Use `matchDepNames` instead of `matchPackageNames`

### DIFF
--- a/default.json
+++ b/default.json
@@ -57,7 +57,7 @@
 			"matchManagers": [
 				"composer"
 			],
-			"matchPackageNames": [
+			"matchDepNames": [
 				"php"
 			],
 			"rangeStrategy": "widen"


### PR DESCRIPTION
`matchPackageNames` should be preferred over `matchDepNames`. Don't know why.