### PR TITLE
[BUGFIX] Use `[SECURITY]` as prefix in vulnerability PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -90,6 +90,8 @@
 			":automergeDisabled",
 			":automergePr"
 		],
+		"commitMessagePrefix": "[SECURITY]",
+		"commitMessageSuffix": null,
 		"rangeStrategy": "replace"
 	}
 }


### PR DESCRIPTION
The default config uses `[SECURITY]` as suffix, but we prefer usage as prefix.