### PR TITLE
[FEATURE] Add support for PHP version updates in DDEV config

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,6 +36,18 @@
 			"datasourceTemplate": "docker",
 			"depNameTemplate": "php",
 			"versioningTemplate": "docker"
+		},
+		{
+			"customType": "regex",
+			"fileMatch": [
+				"^\\.ddev/config\\.yaml$"
+			],
+			"matchStrings": [
+				"php_version: \"(?<currentValue>\\d\\.\\d\\S*)\""
+			],
+			"datasourceTemplate": "docker",
+			"depNameTemplate": "php",
+			"versioningTemplate": "docker"
 		}
 	],
 	"dependencyDashboardOSVVulnerabilitySummary": "unresolved",


### PR DESCRIPTION
This PR adds support for PHP version updates in `.ddev/config.yaml` files.