### PR TITLE
[TASK] Use GitHub releases of php/php-src for PHP updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,9 +33,9 @@
 			"matchStrings": [
 				"php-version: '?(?<currentValue>\\d\\.\\d\\S*)'?"
 			],
-			"datasourceTemplate": "docker",
-			"depNameTemplate": "php",
-			"versioningTemplate": "docker"
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "php/php-src",
+			"versioningTemplate": "regex:^php-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)"
 		},
 		{
 			"customType": "regex",
@@ -45,9 +45,9 @@
 			"matchStrings": [
 				"[^ ]php_version: \"(?<currentValue>\\d\\.\\d)\""
 			],
-			"datasourceTemplate": "docker",
-			"depNameTemplate": "php",
-			"versioningTemplate": "docker"
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "php/php-src",
+			"versioningTemplate": "regex:^php-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)"
 		}
 	],
 	"dependencyDashboardOSVVulnerabilitySummary": "unresolved",
@@ -61,6 +61,7 @@
 	"osvVulnerabilityAlerts": true,
 	"packageRules": [
 		{
+			"groupName": "PHP",
 			"description": "Handle PHP requirement specifically",
 			"extends": [
 				":automergeDisabled"
@@ -71,11 +72,13 @@
 				"custom.regex"
 			],
 			"matchDepNames": [
-				"php"
+				"php",
+				"php/php-src"
 			],
 			"rangeStrategy": "widen"
 		},
 		{
+			"groupName": "PHP",
 			"description": "Override commit message for PHP version updates in GitHub workflows",
 			"commitMessageTopic": "{{{depName}}}",
 			"matchFileNames": [
@@ -85,23 +88,23 @@
 				"custom.regex"
 			],
 			"matchDepNames": [
-				"php"
+				"php/php-src"
 			]
 		},
 		{
+			"groupName": "GitHub artifact actions",
 			"description": "Group GitHub artifact actions",
 			"matchDepNames": [
 				"actions/download-artifact",
 				"actions/upload-artifact"
-			],
-			"groupName": "GitHub artifact actions"
+			]
 		},
 		{
+			"groupName": "Doctrine packages",
 			"description": "Group Doctrine packages",
 			"matchPackageNames": [
 				"doctrine/**"
-			],
-			"groupName": "Doctrine packages"
+			]
 		}
 	],
 	"platformAutomerge": true,

--- a/deployer.json
+++ b/deployer.json
@@ -25,6 +25,7 @@
 	],
 	"packageRules": [
 		{
+			"groupName": "PHP",
 			"description": "Disable automerge for PHP version updates in GitHub deploy workflow",
 			"extends": [
 				":automergeDisabled"
@@ -36,7 +37,7 @@
 				"custom.regex"
 			],
 			"matchDepNames": [
-				"php"
+				"php/php-src"
 			]
 		}
 	]

--- a/symfony-project.json
+++ b/symfony-project.json
@@ -19,6 +19,7 @@
 	],
 	"packageRules": [
 		{
+			"groupName": "Symfony",
 			"description": "Disable automerge for Symfony framework updates since they may require additional work",
 			"extends": [
 				":automergeDisabled"

--- a/typo3-extension.json
+++ b/typo3-extension.json
@@ -12,13 +12,13 @@
 			"rangeStrategy": "widen"
 		},
 		{
-			"description": "Group TYPO3 CMS dependencies",
+			"groupName": "TYPO3 CMS",
+			"description": "TYPO3 CMS dependencies",
 			"matchPackageNames": [
 				"typo3/cms-**",
 				"!typo3/cms-cli",
 				"!typo3/cms-composer-installers"
 			],
-			"groupName": "TYPO3 CMS",
 			"fetchChangeLogs": "off"
 		},
 		{
@@ -43,7 +43,7 @@
 				"custom.regex"
 			],
 			"matchDepNames": [
-				"php"
+				"php/php-src"
 			]
 		}
 	]


### PR DESCRIPTION
This PR changes the source for PHP updates to GitHub releases of `php/php-src`.