### PR TITLE
[BUGFIX] Ignore `ext-sodium` for TYPO3 extensions and projects

### DIFF
--- a/typo3-extension.json
+++ b/typo3-extension.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"composerIgnorePlatformReqs": [
-		"ext-intl"
+		"ext-intl",
+		"ext-sodium"
 	],
 	"packageRules": [
 		{

--- a/typo3-project.json
+++ b/typo3-project.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"composerIgnorePlatformReqs": [
-		"ext-intl"
+		"ext-intl",
+		"ext-sodium"
 	],
 	"lockFileMaintenance": {
 		"automerge": false,


### PR DESCRIPTION
This is required since TYPO3 v14 and thus must be ignored from platform requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform requirement configurations to support additional PHP extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->