### PR TITLE
[TASK] Enable minimum release age of 3 days

### DIFF
--- a/default.json
+++ b/default.json
@@ -60,6 +60,7 @@
 		],
 		"commitMessageAction": "Update all dependencies"
 	},
+	"minimumReleaseAge": "3 days",
 	"onboardingPrTitle": "[TASK] Configure Renovate",
 	"osvVulnerabilityAlerts": true,
 	"packageRules": [
@@ -240,6 +241,12 @@
 				"action"
 			],
 			"overrideDatasource": "github-digest"
+		},
+		{
+			"matchDepNames": [
+				"eliashaeussler/**"
+			],
+			"minimumReleaseAge": "0 days"
 		}
 	],
 	"vulnerabilityAlerts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added a recommended minimum release age setting for npm security updates.
  * Updated the recommended configuration group to include this security constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->